### PR TITLE
Mmake kenticoVersion entry an array and rename it to kenticoVersions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `.json` file entry contains details about your projects:
 
 > <sup>3</sup> Recommended is to start version numbering from `1.0.0`, but there are no limitations until the versioning following the [semantic versioning](http://semver.org). Specified version is supposed to be bound to the last entry of the `kenticoVersions` array.
 
-> <sup>4</sup> A Version of the Kentico EMS that the extension is referencing. The array is for keeping the record what version was the extension released in the past. The last one is assumed to be bound to the `version` record. A recommended approach is to have a table explaining what extension version is compatible with what Kentico EMS version in the description linked in `sourceUrl` attribute.
+> <sup>4</sup> A version of the Kentico EMS that the extension is referencing. The array is for keeping the record of what Kentico version was supported in past extension releases. The last one is assumed to be bound to the `version` record. A recommended approach is to have a table mapping the extension version to Kentico EMS version in the description linked in `sourceUrl` attribute.
 
 ## Updating an extension
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `.json` file entry contains details about your projects:
 
 > <sup>2</sup> If you want to bind your activity with Kentico Partner Program, provide the company name.
 
-> <sup>3</sup> Recommended is to start version numbering from `1.0.0`, but there are no limitations until the versioning following the [semantic versioning](http://semver.org). Specified version is supposed to be bound to the last entry of the `kenticoVersionsArray`.
+> <sup>3</sup> Recommended is to start version numbering from `1.0.0`, but there are no limitations until the versioning following the [semantic versioning](http://semver.org). Specified version is supposed to be bound to the last entry of the `kenticoVersions` array.
 
 > <sup>4</sup> Version of the Kentico EMS that the extension is referencing. The array is for keeping the record what version were the extension released in the past. Last one is assumed to be bound to the `version` record. Recommended approach is to have a table explaining what extension version is compatible with what Kentico EMS version in the description linked in `sourceUrl` attribute.
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ The `.json` file entry contains details about your projects:
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/kentico-icon.png",
     "author": "kentico",
     "sourceUrl": "https://github.com/Kentico/ems-mvc-components#warning-this-repo-is-in-development",
-    "version": "1.0.0",
-    "kenticoVersion": "12.0.29",
+    "version": "1.1.42",
+    "kenticoVersions": [
+      "12.0.0"
+      "12.0.29"
+    ],
     "category": "mvc widget",
     "tags": [
        "mvc",
@@ -68,8 +71,8 @@ The `.json` file entry contains details about your projects:
 | thumbnailUrl<sup>1</sup>      | string | Url to the thumbnail image (must be jpg/jpeg/png with 100x100px resolution and using the HTTPS). |
 | author<sup>2</sup>      | string | Name of the author and company if aplicable. (max 40 characters).|
 | sourceUrl      | string | Url to the extension (must be using HTTPS).|
-| version<sup>3</sup>      | string | Extension version (must follow [semantic versioning](http://semver.org)).|
-| kenticoVersion      | string | Kentico supported version (must follow [semantic versioning](http://semver.org)).|
+| version<sup>3</sup>      | string | Last version of the extension version (must follow the [semantic versioning](http://semver.org)).|
+| kenticoVersions<sup>4</sup>      | array of strings | Kentico supported versions (version entries must follow the [semantic versioning](http://semver.org)).|
 | category      | string | Category of the extension. (One of these string `module`, `webpart`, `website template`, `utility`, `mvc widget`, `mvc section`, `mvc form component`, `mvc inline editor`, `mvc personalization condition type`, `other`)|
 | tag      | array of strings | List that tags you want to mark an extension with.|
 
@@ -77,8 +80,9 @@ The `.json` file entry contains details about your projects:
 
 > <sup>2</sup> If you want to bind your activity with Kentico Partner Program, provide the company name.
 
-> <sup>3</sup> Recommended is to start version numbering from 1.0.0, but there are no limitations until the versioning foolowing the [semantic versioning](http://semver.org).
+> <sup>3</sup> Recommended is to start version numbering from `1.0.0`, but there are no limitations until the versioning following the [semantic versioning](http://semver.org). Specified version is supposed to be bound to the last entry of the `kenticoVersionsArray`.
 
+> <sup>4</sup> Version of the Kentico EMS that the extension is referencing. The array is for keeping the record what version were the extension released in the past. Last one is assumed to be bound to the `version` record. Recommended approach is to have a table explaining what extension version is compatible with what Kentico EMS version in the description linked in `sourceUrl` attribute.
 
 ## Updating an extension
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `.json` file entry contains details about your projects:
 
 > <sup>3</sup> Recommended is to start version numbering from `1.0.0`, but there are no limitations until the versioning following the [semantic versioning](http://semver.org). Specified version is supposed to be bound to the last entry of the `kenticoVersions` array.
 
-> <sup>4</sup> Version of the Kentico EMS that the extension is referencing. The array is for keeping the record what version were the extension released in the past. Last one is assumed to be bound to the `version` record. Recommended approach is to have a table explaining what extension version is compatible with what Kentico EMS version in the description linked in `sourceUrl` attribute.
+> <sup>4</sup> A Version of the Kentico EMS that the extension is referencing. The array is for keeping the record what version was the extension released in the past. The last one is assumed to be bound to the `version` record. A recommended approach is to have a table explaining what extension version is compatible with what Kentico EMS version in the description linked in `sourceUrl` attribute.
 
 ## Updating an extension
 

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -6,7 +6,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/ems-mvc-components#warning-this-repo-is-in-development",
     "version": "1.0.0-beta1",
-    "kenticoVersion": "12.0.29",
+    "kenticoVersions": [
+      "12.0.29"
+    ],
     "category": "mvc widget",
     "tags": [
       "mvc",
@@ -22,7 +24,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/KInspector",
     "version": "3.9.0",
-    "kenticoVersion": "12.0.0",
+    "kenticoVersions": [
+      "12.0.0"
+    ],
     "category": "module",
     "tags": [
       "health",
@@ -39,7 +43,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/DisqusThread",
     "version": "1.1.0",
-    "kenticoVersion": "10.0.0",
+    "kenticoVersions": [
+      "10.0.0"
+    ],
     "category": "webpart",
     "tags": [
       "community",
@@ -55,7 +61,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/ADImportService",
     "version": "1.1.0",
-    "kenticoVersion": "8.0.0",
+    "kenticoVersions": [
+      "8.0.0"
+    ],
     "category": "utility",
     "tags": [
       "active directory",
@@ -72,7 +80,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/ADImport",
     "version": "12.0.0",
-    "kenticoVersion": "12.0.0",
+    "kenticoVersions": [
+      "12.0.0"
+    ],
     "category": "utility",
     "tags": [
       "active directory",
@@ -89,7 +99,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/kentico-amp",
     "version": "12.0.0",
-    "kenticoVersion": "12.0.0",
+    "kenticoVersions": [
+      "12.0.0"
+    ],
     "category": "module",
     "tags": [
       "google-amp",
@@ -104,7 +116,9 @@
     "author": "Chris Crutchfield",
     "sourceUrl": "https://github.com/clcrutch/posh-kentico",
     "version": "0.2.0",
-    "kenticoVersion": "11.0.0",
+    "kenticoVersions": [
+      "11.0.0"
+    ],
     "category": "module",
     "tags": [
       "powershell",
@@ -119,7 +133,9 @@
     "author": "Lee Conlin",
     "sourceUrl": "https://github.com/hades200082/Kentico12-MVC-WidgetResolver",
     "version": "1.0.1",
-    "kenticoVersion": "12.0.0",
+    "kenticoVersions": [
+      "12.0.0"
+    ],
     "category": "utility",
     "tags": [
       "mvc",
@@ -135,7 +151,9 @@
     "author": "Ntara",
     "sourceUrl": "https://github.com/Ntara/Kentico.PackageBuilder",
     "version": "1.0.0",
-    "kenticoVersion": "11.0.0",
+    "kenticoVersions": [
+      "11.0.0"
+    ],
     "category": "utility",
     "tags": [
       "module",

--- a/scripts/checkExtensionsFormat.js
+++ b/scripts/checkExtensionsFormat.js
@@ -8,7 +8,7 @@ const extensionSchema = Joi.object().keys({
   author: Joi.string().max(40).required(),
   sourceUrl: Joi.string().uri({ scheme: 'https' }).required(),
   version: Joi.string().regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/).required(),
-  kenticoVersion: Joi.string().regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/).required(),
+  kenticoVersions: Joi.array().items(Joi.string().regex(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/).required()),
   category: Joi.any().valid(
     'module',
     'webpart',


### PR DESCRIPTION
### Motivation

To be able to filter component that is implemented for different Kentico version - basically to have the data to filter by.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

The automatic check should do the trick - please check the readme if it is clear.
