### PR TITLE
Fixing a typo in CRM Connect

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -233,7 +233,7 @@
   },
   {
     "name": "CRM Connect 2.0",
-    "description": "RM Connect for Kentico enables the seamless integration of your digital marketing and sales efforts.",
+    "description": "CRM Connect for Kentico enables the seamless integration of your digital marketing and sales efforts.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/generic-integration.png",
     "author": "EMAKINA CEE",
     "sourceUrl": "http://kentico-emakina.de/crm-connect",


### PR DESCRIPTION
Changed "RM Connect" to "CRM Connect".

### Motivation
https://github.com/Kentico/devnet.kentico.com/issues/25

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?

Check if the typo has been fixed on the website.