### PR TITLE
Fix icon according to the requirements

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -281,7 +281,7 @@
   {
     "name": "Bootstrap 4 Layout Tool",
     "description": "Kentico MVC Page Builder Section that allows you to configure the number of columns, sizes, additional classes, etc.",
-    "thumbnailUrl": "https://getbootstrap.com/docs/4.0/assets/img/favicons/favicon.ico",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/bootstrap-icon.png",
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/BootstrapLayoutTool/blob/master/README.md",
     "version": "12.29.2",


### PR DESCRIPTION
### Motivation

The original icon looked blurry on the marketplace:
![image](https://user-images.githubusercontent.com/9218736/63083313-b2cf6e80-bf48-11e9-9137-638b61cfb97c.png)

And it does not fulfill the [requirements](https://github.com/Kentico/devnet.kentico.com#how-to-qualify)

### Solution

Fix icon according to the requirements.

I have used official bootstrap icon according to [Bootstrap  brand guidelines](https://v4-alpha.getbootstrap.com/about/brand/#download-mark).