### PR TITLE
Added disqus MVC widget to extensions.json

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -546,5 +546,22 @@
       "caching"
 
     ]
+  },
+  {
+    "name": "Disqus Thread MVC Widget",
+    "description": "Disqus thread MVC widget for Kentico.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/avivasolutionsnl/kentico-mvc-widget-disqus/master/aviva-solutions.png",
+    "author": "Aviva Solutions",
+    "sourceUrl": "https://github.com/avivasolutionsnl/kentico-mvc-widget-disqus",
+    "version": "1.0.0",
+    "kenticoVersions": [
+      "12.0.38"
+    ],
+    "category": "mvc widget",
+    "tags": [
+      "mvc",
+      "comments",
+      "disqus"
+    ]
   }
 ]


### PR DESCRIPTION
### Motivation

Kentico disqus widget allows you to easily add the widget to your MVC project. Source code will be added and can be easily modified.