### PR TITLE
Adding a YouTube video selector widget for Kentico EMS MVC

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -668,5 +668,24 @@
       "fullCalendar",
       "events"
     ]
+  },
+  {
+    "name": "YouTube Video Selector",
+    "description": "Enables the editor to search for videos on YouTube using plain text to lookup by title, description or video ID. Further advanced settings allow for finer control of the video embed.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/mattnield/kentico-youtube-selector-widget/master/youtube_social_icon_red.png",
+    "author": "Matt Nield - Ridgeway",
+    "sourceUrl": "https://github.com/mattnield/kentico-youtube-selector-widget",
+    "version": "12.0.0",
+    "kenticoVersions": [
+      "12.0.0"
+    ],
+    "category": "mvc widget",
+    "tags": [
+      "YouTube",
+      "mvc",
+      "video",
+      "inline",
+      "video search"
+    ]
   }
 ]

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -671,7 +671,7 @@
   },
   {
     "name": "YouTube Video Selector",
-    "description": "Enables the editor to search for videos on YouTube using plain text to lookup by title, description or video ID. Further advanced settings allow for finer control of the video embed.",
+    "description": "Enables the editor to search for videos on YouTube using plain-text to lookup by title or ID. Advanced settings allow for control of the video embed.",
     "thumbnailUrl": "https://raw.githubusercontent.com/mattnield/kentico-youtube-selector-widget/master/youtube_social_icon_red.png",
     "author": "Matt Nield - Ridgeway",
     "sourceUrl": "https://github.com/mattnield/kentico-youtube-selector-widget",

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -675,7 +675,7 @@
     "thumbnailUrl": "https://raw.githubusercontent.com/mattnield/kentico-youtube-selector-widget/master/youtube_social_icon_red.png",
     "author": "Matt Nield - Ridgeway",
     "sourceUrl": "https://github.com/mattnield/kentico-youtube-selector-widget",
-    "version": "12.0.0",
+    "version": "1.0.0",
     "kenticoVersions": [
       "12.0.0"
     ],


### PR DESCRIPTION
### Motivation

Adding a new MVC widget to the market place that allows users to search for videos on YouTub using an API key. The user can either search by video title or directly ender a video ID.

Additional control is enabled by the properties dialogue.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Import the NuGet package (follow install instructions to ensure vue.js is registered) and add the widget to a page builder zone. Typing into the search box will update the page displaying the thumbnails of matching videos.
