### PR TITLE
Version bump of Content components module

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -477,7 +477,7 @@
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/generic-integration.png",
     "author": "Chris Meagher",
     "sourceUrl": "https://github.com/CMeeg/kentico-contrib/tree/master/src/Meeg.Kentico.ContentComponents",
-    "version": "0.1.0",
+    "version": "0.3.0",
     "kenticoVersions": ["12.0.39"],
     "category": "module",
     "tags": ["content", "content modelling", "page types"]


### PR DESCRIPTION
I've made some changes to the module so this change reflects the latest version number of the packages on NuGet.
