### PR TITLE
Broken web part link in Kentico Marketplace portal

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -7,7 +7,7 @@
     "sourceUrl": "https://github.com/vasu-rbt/K10Covid19Webparts",
     "version": "1.0.0",
     "kenticoVersions": ["10.0.0", "12.0.29"],
-    "category": "web part",
+    "category": "webpart",
     "tags": ["COVID-19", "Coronavirus", "Statistics", "Country"]
   },
 {

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -1,7 +1,7 @@
 [
 {
     "name": "COVID-19 World or Country Statistics",
-    "description": "Render COVID-19 Corona virus world/country statistics using https://rapidapi.com/KishCom/api/covid-19-coronavirus-statistics API.",
+    "description": "Render COVID-19 Corona virus world/country statistics using rapidapi (i.e. https://rapidapi.com/KishCom/api/covid-19-coronavirus-statistics).",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/K10Covid19Webparts",

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -1,7 +1,7 @@
 [
 {
-    "name": "Coronavirus World/Country Statistics",
-    "description": "Render COVID-19 Corona virus world/country Statistics using https://rapidapi.com/KishCom/api/covid-19-coronavirus-statistics API",
+    "name": "COVID-19 World or Country Statistics",
+    "description": "Render COVID-19 Corona virus world/country statistics using https://rapidapi.com/KishCom/api/covid-19-coronavirus-statistics API.",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/K10Covid19Webparts",

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -1,6 +1,6 @@
 [
 {
-    "name": "COVID-19 World or Country Statistics",
+    "name": "COVID-19 Statistics",
     "description": "Render COVID-19 Corona virus world/country statistics using rapidapi (i.e. https://rapidapi.com/KishCom/api/covid-19-coronavirus-statistics).",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",


### PR DESCRIPTION
Broken web part link in Kentico Marketplace portal due to added "/" in web part name.
Now I corrected. 

Please approve this pull request.