### PR TITLE
Add baseline sites

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -951,7 +951,7 @@
     "sourceUrl": "https://github.com/HBSTech/Kentico13CoreBaseline",
     "version": "1.0.0",
     "kenticoVersions": ["13.0.5"],
-    "category": "website",
+    "category": "website template",
     "tags": ["baseline", "mvc", "core", "site"]
   },
   {
@@ -962,7 +962,7 @@
     "sourceUrl": "https://github.com/HBSTech/Kentico12Baseline",
     "version": "1.0.0",
     "kenticoVersions": ["12.0.79"],
-    "category": "website",
+    "category": "website template",
     "tags": ["baseline", "mvc", "core", "site"]
   }
 ]

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -942,5 +942,27 @@
     "kenticoVersions": ["12.0.29"],
     "category": "webpart",
     "tags": ["cta", "button", "widget", "web part"]
+  },
+  {
+    "name": "Kentico 13 Core Baseline",
+    "description": "A theme-less .net Core 5.0 MVC starting site template with common site elements, tools, and systems to get your site going fast.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/HBS-Logo.png",
+    "author": "Trevor Fayas -Heartland Business Systems",
+    "sourceUrl": "https://github.com/HBSTech/Kentico13CoreBaseline",
+    "version": "1.0.0",
+    "kenticoVersions": ["13.0.5"],
+    "category": "website",
+    "tags": ["baseline", "mvc", "core", "site"]
+  },
+  {
+    "name": "Kentico 12 Baseline",
+    "description": "A theme-less .Net MVC starting site template with common site elements, tools, and systems to get your site going fast.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/HBS-Logo.png",
+    "author": "Trevor Fayas -Heartland Business Systems",
+    "sourceUrl": "https://github.com/HBSTech/Kentico13CoreBaseline",
+    "version": "1.0.0",
+    "kenticoVersions": ["12.0.79"],
+    "category": "website",
+    "tags": ["baseline", "mvc", "core", "site"]
   }
 ]

--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -959,7 +959,7 @@
     "description": "A theme-less .Net MVC starting site template with common site elements, tools, and systems to get your site going fast.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/HBS-Logo.png",
     "author": "Trevor Fayas -Heartland Business Systems",
-    "sourceUrl": "https://github.com/HBSTech/Kentico13CoreBaseline",
+    "sourceUrl": "https://github.com/HBSTech/Kentico12Baseline",
     "version": "1.0.0",
     "kenticoVersions": ["12.0.79"],
     "category": "website",


### PR DESCRIPTION
Added Previous Kentico 12 Baseline Site, and new Kentico 13 .net Core 5.0 Baseline Site.  These sites provide starting points for development and provide common site tools and features.
