### PR TITLE
Updated versions for Full Calendar Widget

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -823,8 +823,8 @@
     "thumbnailUrl": "https://raw.githubusercontent.com/drilic/kentico-mvcwidget-fullcalendar/master/exlrt-logo-clear.png",
     "author": "Dragoljub Ilic (EXLRT)",
     "sourceUrl": "https://github.com/drilic/kentico-mvcwidget-fullcalendar/",
-    "version": "1.0.0",
-    "kenticoVersions": ["12.0.41"],
+    "version": "2.0.0",
+    "kenticoVersions": ["12.0.41", "13.0.97"],
     "category": "mvc widget",
     "tags": ["mvc", "widget", "calendar", "fullCalendar", "events"]
   },


### PR DESCRIPTION
### Motivation

Updated previous version (Kentico 12) to supports Kentico 13
