### PR TITLE
Add Video Widget To Marketplace

### DIFF
--- a/marketplace/extensions.json
+++ b/marketplace/extensions.json
@@ -1,280 +1,280 @@
 [
-{
+  {
     "name": "Twilio SMS",
     "description": "Integrates the Twilio SMS API and provides a Marketing Automation action to send messages to your customers.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-twilio-sms/master/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-twilio-sms",
     "version": "0.0.4",
-    "kenticoVersions": ["13.0.73"],
+    "kenticoVersions": [ "13.0.73" ],
     "category": "integration",
-    "tags": ["twilio", "sms", "marketing automation"]
-},
-{
+    "tags": [ "twilio", "sms", "marketing automation" ]
+  },
+  {
     "name": "Xperience by Kentico Algolia Search",
     "description": "Enables the creation of Algolia search indexes and the indexing of Xperience content tree pages using a code-first approach.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-by-kentico-algolia/master/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-by-kentico-algolia",
     "version": "1.0.0",
-    "kenticoVersions": ["22.3.0"],
+    "kenticoVersions": [ "22.3.0" ],
     "category": "integration",
-    "tags": ["algolia", "search", "faceted search", "personalization", ".net core"]
-},
-{
+    "tags": [ "algolia", "search", "faceted search", "personalization", ".net core" ]
+  },
+  {
     "name": "Bynder image selector",
     "description": "Adds the Bynder image selector form control for Xperience administration forms.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/xperience-icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-module-bynder",
     "version": "0.1.1",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["integration", "bynder", "digital asset management", "form component"]
-},
-{
+    "tags": [ "integration", "bynder", "digital asset management", "form component" ]
+  },
+  {
     "name": "Looker Studio",
     "description": "Use data from your Kentico Xperience website in Looker Studio reports.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-google-lookerstudio/master/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-google-lookerstudio",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["data studio", "reporting", "analytics", "looker studio"]
-},
-{
+    "tags": [ "data studio", "reporting", "analytics", "looker studio" ]
+  },
+  {
     "name": "hCaptcha",
     "description": "Kentico Xperience 13.0.66 (or higher) ASP.NET Core 6.0+ Form Component that adds hCaptcha captcha validation to Form Builder forms.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-hcaptcha",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.66"],
+    "kenticoVersions": [ "13.0.66" ],
     "category": "mvc form component",
-    "tags": ["asp.net core", "hcaptcha", "captcha", "component"]
-},
-{
+    "tags": [ "asp.net core", "hcaptcha", "captcha", "component" ]
+  },
+  {
     "name": "Disqus widget",
     "description": "A pagebuilder widget which enables Disqus commenting on your Xperience by Kentico website.",
     "thumbnailUrl": "https://github.com/Kentico/xperience-disqus/raw/xbk/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-disqus/tree/xbk",
     "version": "1.0.0",
-    "kenticoVersions": ["22.0.3"],
+    "kenticoVersions": [ "22.0.3" ],
     "category": "integration",
-    "tags": ["core", "component", "widget", "disqus", "comments"]
-},
-{
+    "tags": [ "core", "component", "widget", "disqus", "comments" ]
+  },
+  {
     "name": "SendGrid",
     "description": "Dispatches Xperience emails using SendGrid's Web API, handles SendGrid events, and provides an interface to manage Xperience and SendGrid suppressions.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-twilio-sendgrid/master/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-twilio-sendgrid",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.73"],
+    "kenticoVersions": [ "13.0.73" ],
     "category": "integration",
-    "tags": ["sendgrid", "email", "email marketing"]
-},
-{
+    "tags": [ "sendgrid", "email", "email marketing" ]
+  },
+  {
     "name": "Dynamics 365",
     "description": "An integration for synchronizing contacts and activities between Kentico Xperience and Microsoft Dynamics 365.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-dynamics365-sales/master/Assets/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-dynamics365-sales",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["dynamics365", "contacts", "activities"]
-},
-{
+    "tags": [ "dynamics365", "contacts", "activities" ]
+  },
+  {
     "name": "Google Search Console",
     "description": "Allows Xperience users to view the indexed status of your Xperience website pages from Google Search Console, and request re-indexing.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-google-searchconsole/master/Assets/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-google-searchconsole",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["google", "google search", "seo"]
-},
-{
+    "tags": [ "google", "google search", "seo" ]
+  },
+  {
     "name": "Page Navigation Redirects",
     "description": "An ASP.NET Core ResourceFilter that can redirect HTTP requests to other URLs, configurable per-Page from the Xperience Administration application.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-page-navigation-redirects",
     "version": "1.1.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "utility",
-    "tags": ["asp.net core", "redirects", "page types", "navigation"]
-},
-{
+    "tags": [ "asp.net core", "redirects", "page types", "navigation" ]
+  },
+  {
     "name": "SVG Media Dimensions",
     "description": "Sets the width/height of SVG images when uploaded/updated in the Administration application of Kentico Xperience 13 sites.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-svg-media-dimensions",
     "version": "1.1.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "module",
-    "tags": ["svg", "media library", "attachments"]
-},
-{
+    "tags": [ "svg", "media library", "attachments" ]
+  },
+  {
     "name": "Page Template Utilities",
     "description": "Utilities to help quickly create and register MVC Page Templates in Kentico Xperience.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-page-template-utilities",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "utility",
-    "tags": ["asp.net core", "page templates", "page types"]
-},
-{
+    "tags": [ "asp.net core", "page templates", "page types" ]
+  },
+  {
     "name": "Page Custom Data Control Extender",
     "description": "A Kentico Xperience Form Control Extender that syncs the Form Control value to/from Page CustomData fields.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-page-custom-data-control-extender",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "other",
-    "tags": ["form control", "content", "web forms", "page types"]
-},
-{
+    "tags": [ "form control", "content", "web forms", "page types" ]
+  },
+  {
     "name": "Page Builder Utilities",
     "description": "ASP.NET Core Tag Helpers and abstractions for the Page Builder in Kentico Xperience applications.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-page-builder-utilities",
     "version": "1.1.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "utility",
-    "tags": ["page builder", "razor", "tag helper", "asp.net core"]
-},
-{
+    "tags": [ "page builder", "razor", "tag helper", "asp.net core" ]
+  },
+  {
     "name": "Page Link Tag Helpers",
     "description": "Kentico Xperience 13.0 ASP.NET Core Tag Helper that generates links to pages from NodeGUID values.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-page-link-tag-helpers",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "other",
-    "tags": ["link", "content", "tag helper", "asp.net core"]
-},
-{
+    "tags": [ "link", "content", "tag helper", "asp.net core" ]
+  },
+  {
     "name": "Algolia search",
     "description": "Enables the creation of Algolia search indexes and the indexing of Xperience content tree pages using a code-first approach.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-algolia/master/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-algolia",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.16"],
+    "kenticoVersions": [ "13.0.16" ],
     "category": "integration",
-    "tags": ["algolia", "search", "faceted search", "personalization", ".net core"]
-},
-{
+    "tags": [ "algolia", "search", "faceted search", "personalization", ".net core" ]
+  },
+  {
     "name": "Xperience Community: RSS Feeds",
     "description": "RSS Feed Integration for ASP.NET Core based Kentico Xperience 13.0 applications using Content Tree Routing.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/wv-logo.png",
     "author": "WiredViews",
     "sourceUrl": "https://github.com/wiredviews/xperience-rss-feeds",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["rss", "page types", "content", "asp.net core"]
-},
-{
+    "tags": [ "rss", "page types", "content", "asp.net core" ]
+  },
+  {
     "name": "Jira Automation",
     "description": "Provides custom Workflow and Marketing automation actions to integrate Jira issues with Kentico Xperience.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/xperience-jira/master/assets/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-jira",
     "version": "1.0.4",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["workflow", "marketing automation", "automation", "jira"]
-},
-{
+    "tags": [ "workflow", "marketing automation", "automation", "jira" ]
+  },
+  {
     "name": "Disqus widget",
     "description": "A pagebuilder widget which enables Disqus commenting on your .NET Core website.",
     "thumbnailUrl": "https://github.com/Kentico/xperience-disqus/raw/master/img/icon.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-disqus",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.32"],
+    "kenticoVersions": [ "13.0.32" ],
     "category": "mvc widget",
-    "tags": ["core", "component", "widget", "disqus", "comments"]
-},
-{
+    "tags": [ "core", "component", "widget", "disqus", "comments" ]
+  },
+  {
     "name": "Event Calendar",
     "description": "Custom .NET Core ViewComponents meant for displaying calendars of events and enabling event registration using a customizable, modern javascript library.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/xperience-icon.png",
     "author": "Eric Dugre",
     "sourceUrl": "https://github.com/Kentico/xperience-core-events",
     "version": "1.0.3",
-    "kenticoVersions": ["13.0.5"],
+    "kenticoVersions": [ "13.0.5" ],
     "category": "module",
-    "tags": ["core", "component", "widget", "events", "calendar"]
-},
-{
+    "tags": [ "core", "component", "widget", "events", "calendar" ]
+  },
+  {
     "name": ".NET Core Breadcrumbs widget",
     "description": "Provides a widget and inline code for generating breadcrumbs on an Xperience 13 .NET Core site using content tree based routing.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/xperience-icon.png",
     "author": "Eric Dugre",
     "sourceUrl": "https://github.com/kentico-ericd/xperience-core-breadcrumbs",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "other",
-    "tags": ["core", "component", "widget", "breadcrumbs"]
-},
-{
+    "tags": [ "core", "component", "widget", "breadcrumbs" ]
+  },
+  {
     "name": "Kentico Authorization",
     "description": "Provides a [KenticoAuthorize] Attribute that limits access by: User Authenticated, User Names, User Roles, Page ACL Permissions, Resource/Module Permissions.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/HBS-Logo.png",
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/KenticoAuthorization",
     "version": "13.0.1",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "utility",
-    "tags": ["authorization", "ACL", "permissions", "dynamic routing"]
-},
-{
+    "tags": [ "authorization", "ACL", "permissions", "dynamic routing" ]
+  },
+  {
     "name": "Kentico Localization Attributes",
     "description": "Localized variations of the default DataAnnotation Attributes that allow your ErrorMessage to contain and resolve Localized macro expressions",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/HBS-Logo.png",
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/KenticoLocalizedValidationAttributes",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "utility",
-    "tags": ["ValidationAttributes", "Validation", "Localized", "Localization"]
-},
-{
+    "tags": [ "ValidationAttributes", "Validation", "Localized", "Localization" ]
+  },
+  {
     "name": "COVID-19 Country Wise",
     "description": "Render COVID-19 Corona virus country wise data using rapidapi (i.e. https://rapidapi.com/spamakashrajtech/api/corona-virus-world-and-india-data).",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/K10Covid19Webparts",
     "version": "1.0.0",
-    "kenticoVersions": ["10.0.0", "12.0.29"],
+    "kenticoVersions": [ "10.0.0", "12.0.29" ],
     "category": "webpart",
-    "tags": ["COVID-19", "Coronavirus", "Country Wise", "Country"]
+    "tags": [ "COVID-19", "Coronavirus", "Country Wise", "Country" ]
   },
-{
+  {
     "name": "COVID-19 Statistics",
     "description": "Render COVID-19 Corona virus world/country statistics using rapidapi (i.e. https://rapidapi.com/KishCom/api/covid-19-coronavirus-statistics).",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/K10Covid19Webparts",
     "version": "1.0.0",
-    "kenticoVersions": ["10.0.0", "12.0.29"],
+    "kenticoVersions": [ "10.0.0", "12.0.29" ],
     "category": "webpart",
-    "tags": ["COVID-19", "Coronavirus", "Statistics", "Country"]
+    "tags": [ "COVID-19", "Coronavirus", "Statistics", "Country" ]
   },
-{
+  {
     "name": "Registration Form Widget",
     "description": "It displays a form that allows visitors to register on the website as new users.",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
@@ -285,7 +285,7 @@
       "12.0.29"
     ],
     "category": "mvc widget",
-    "tags": ["mvc", "Registration", "Form", "Registration Form","RegistrationForm"]
+    "tags": [ "mvc", "Registration", "Form", "Registration Form", "RegistrationForm" ]
   },
   {
     "name": "Logon Form Widget",
@@ -298,9 +298,9 @@
       "12.0.29"
     ],
     "category": "mvc widget",
-    "tags": ["mvc", "Logon", "Form", "Logon Form","LogonForm","Login Form"]
+    "tags": [ "mvc", "Logon", "Form", "Logon Form", "LogonForm", "Login Form" ]
   },
- {
+  {
     "name": "Textmetrics for Kentico",
     "description": "Textmetrics enables organizations to create high quality and SEO friendly content that matches your target audience and complies to your brand and styleguides.",
     "thumbnailUrl": "https://raw.githubusercontent.com/iNalgiev/devnet.kentico.com/master/marketplace/assets/textmetrics_icon.png",
@@ -311,7 +311,7 @@
       "12.0.0"
     ],
     "category": "module",
-    "tags": ["cms", "module", "text", "seo", "content", "quality", "optimization", "tool"]
+    "tags": [ "cms", "module", "text", "seo", "content", "quality", "optimization", "tool" ]
 
   },
   {
@@ -325,7 +325,7 @@
       "12.0.29"
     ],
     "category": "mvc widget",
-    "tags": ["mvc", "Editable Image", "Editable", "Image"]
+    "tags": [ "mvc", "Editable Image", "Editable", "Image" ]
   },
   {
     "name": "Image Video Carousel",
@@ -338,7 +338,7 @@
       "12.0.29"
     ],
     "category": "mvc widget",
-    "tags": ["mvc", "Image and Video Carousel", "Image Carousel","Video Carousel","Image Slider", "Video Slider","Image","Video", "Slider","Corousel"]
+    "tags": [ "mvc", "Image and Video Carousel", "Image Carousel", "Video Carousel", "Image Slider", "Video Slider", "Image", "Video", "Slider", "Corousel" ]
   },
   {
     "name": "Image Card",
@@ -351,9 +351,9 @@
       "12.0.29"
     ],
     "category": "mvc widget",
-    "tags": ["mvc", "Image Card", "Image with caption and target link","Image","Card"]
+    "tags": [ "mvc", "Image Card", "Image with caption and target link", "Image", "Card" ]
   },
-   {
+  {
     "name": "Repeater",
     "description": "Displays the content of specified page type pages based on the assigned view.",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
@@ -364,7 +364,7 @@
       "12.0.29"
     ],
     "category": "mvc widget",
-    "tags": ["mvc", "Repeater widget", "Repeater"]
+    "tags": [ "mvc", "Repeater widget", "Repeater" ]
   },
   {
     "name": "Google Map Widget",
@@ -381,10 +381,10 @@
       "mvc",
       "Google Map",
       "Google",
-	  "Map",
-	  "Kentico 12"
-]
-  }, 
+      "Map",
+      "Kentico 12"
+    ]
+  },
   {
     "name": "Dynamic Routing",
     "description": "Automatic page route mapping to Controller, Controller+Action, or View using Attributes.  Based on Automatic Url Slugs with custom Urls allowed.",
@@ -392,9 +392,9 @@
     "author": "Trevor Fayas-HBS, Sean Wright-WiredViews",
     "sourceUrl": "https://github.com/KenticoDevTrev/DynamicRouting",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "utility",
-    "tags": ["dynamic routing", "routing", "url"]
+    "tags": [ "dynamic routing", "routing", "url" ]
   },
   {
     "name": "Dynamic Routing Wildcards",
@@ -403,9 +403,9 @@
     "author": "Taylor Smith, Rafe Wilson",
     "sourceUrl": "https://github.com/reallymoving/kentico-dynamic-routing-wildcards",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "utility",
-    "tags": ["dynamic routing wildcard", "routing", "url"]
+    "tags": [ "dynamic routing wildcard", "routing", "url" ]
   },
   {
     "name": "YouTube Video widget",
@@ -414,9 +414,9 @@
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/kentico12-mvc-widgets/tree/master/Raybiztech.Kentico12.MVC.Widgets/Raybiztech.Kentico12.MVC.Widgets.YouTubeVideo",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "mvc widget",
-    "tags": ["mvc", "youtube", "youtue video", "Video"]
+    "tags": [ "mvc", "youtube", "youtue video", "Video" ]
   },
   {
     "name": "Link button widget",
@@ -425,9 +425,9 @@
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/kentico12-mvc-widgets/tree/master/Raybiztech.Kentico12.MVC.Widgets/Raybiztech.Kentico12.MVC.Widgets.LinkButton",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "mvc widget",
-    "tags": ["mvc", "Link", "Link button"]
+    "tags": [ "mvc", "Link", "Link button" ]
   },
   {
     "name": "Video widget",
@@ -436,9 +436,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-component-samples/tree/master/Kentico.Widget.Video#video-widget",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.31"],
+    "kenticoVersions": [ "12.0.31" ],
     "category": "mvc widget",
-    "tags": ["mvc", "youtube", "video", "inline-editor"]
+    "tags": [ "mvc", "youtube", "video", "inline-editor" ]
   },
   {
     "name": "Rich Text Editor Widget",
@@ -447,9 +447,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-component-samples/tree/687639b20551d21b70f1966f29624ee88cf22d89/Kentico.Widget.RichText#rich-text-widget",
     "version": "1.3.0",
-    "kenticoVersions": ["12.0.79"],
+    "kenticoVersions": [ "12.0.79" ],
     "category": "mvc widget",
-    "tags": ["mvc", "rich-text", "wysiwyg", "froala", "rich", "text", "editor"]
+    "tags": [ "mvc", "rich-text", "wysiwyg", "froala", "rich", "text", "editor" ]
   },
   {
     "name": "Rich Text Inline Editor",
@@ -458,9 +458,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-component-samples/tree/687639b20551d21b70f1966f29624ee88cf22d89/Kentico.InlineEditor.RichText#rich-text-inline-editor",
     "version": "1.3.0",
-    "kenticoVersions": ["12.0.79"],
+    "kenticoVersions": [ "12.0.79" ],
     "category": "mvc inline editor",
-    "tags": ["mvc", "rich-text", "wysiwyg", "froala", "rich", "text", "editor"]
+    "tags": [ "mvc", "rich-text", "wysiwyg", "froala", "rich", "text", "editor" ]
   },
   {
     "name": "KInspector",
@@ -469,9 +469,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/KInspector",
     "version": "3.9.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "module",
-    "tags": ["health", "performance", "security", "monitoring", "analysis"]
+    "tags": [ "health", "performance", "security", "monitoring", "analysis" ]
   },
   {
     "name": "Disqus Thread",
@@ -480,9 +480,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/DisqusThread",
     "version": "1.1.0",
-    "kenticoVersions": ["10.0.0"],
+    "kenticoVersions": [ "10.0.0" ],
     "category": "webpart",
-    "tags": ["community", "forums", "discussions", "chat"]
+    "tags": [ "community", "forums", "discussions", "chat" ]
   },
   {
     "name": "AD Import Service",
@@ -491,9 +491,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/ADImportService",
     "version": "1.1.0",
-    "kenticoVersions": ["8.0.0"],
+    "kenticoVersions": [ "8.0.0" ],
     "category": "utility",
-    "tags": ["active directory", "ad", "membership", "import", "authentication"]
+    "tags": [ "active directory", "ad", "membership", "import", "authentication" ]
   },
   {
     "name": "AD Import Utility",
@@ -502,9 +502,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/ADImport",
     "version": "12.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "utility",
-    "tags": ["active directory", "ad", "membership", "import", "authentication"]
+    "tags": [ "active directory", "ad", "membership", "import", "authentication" ]
   },
   {
     "name": "Kentico AMP",
@@ -513,9 +513,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/kentico-amp",
     "version": "12.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "module",
-    "tags": ["google-amp", "amp-html", "amp-filter"]
+    "tags": [ "google-amp", "amp-html", "amp-filter" ]
   },
   {
     "name": "PoSH Kentico",
@@ -524,9 +524,9 @@
     "author": "Chris Crutchfield",
     "sourceUrl": "https://github.com/clcrutch/posh-kentico",
     "version": "0.2.0",
-    "kenticoVersions": ["11.0.0"],
+    "kenticoVersions": [ "11.0.0" ],
     "category": "module",
-    "tags": ["powershell", "administration", "kentico-cms"]
+    "tags": [ "powershell", "administration", "kentico-cms" ]
   },
   {
     "name": "Kentico MVC Widget Resolver",
@@ -535,9 +535,9 @@
     "author": "Lee Conlin",
     "sourceUrl": "https://github.com/hades200082/Kentico12-MVC-WidgetResolver",
     "version": "1.0.1",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "utility",
-    "tags": ["mvc", "kentico 12", "structured content", "rich text"]
+    "tags": [ "mvc", "kentico 12", "structured content", "rich text" ]
   },
   {
     "name": "Package Builder",
@@ -546,9 +546,9 @@
     "author": "Ntara",
     "sourceUrl": "https://github.com/Ntara/Kentico.PackageBuilder",
     "version": "1.0.0",
-    "kenticoVersions": ["11.0.0"],
+    "kenticoVersions": [ "11.0.0" ],
     "category": "utility",
-    "tags": ["module", "package", "command-line", "continuous integration"]
+    "tags": [ "module", "package", "command-line", "continuous integration" ]
   },
   {
     "name": "Relationships Extended",
@@ -557,7 +557,7 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/RelationshipsExtended",
     "version": "13.0.3",
-    "kenticoVersions": ["12.29.0", "13.0.0"],
+    "kenticoVersions": [ "12.29.0", "13.0.0" ],
     "category": "module",
     "tags": [
       "relationships",
@@ -574,9 +574,9 @@
     "author": "BizStream",
     "sourceUrl": "https://www.toolkitforkentico.com/extensions/siteimprove-for-kentico",
     "version": "2.0.69",
-    "kenticoVersions": ["10.0.0", "11.0.0", "12.0.0"],
+    "kenticoVersions": [ "10.0.0", "11.0.0", "12.0.0" ],
     "category": "integration",
-    "tags": ["integration"]
+    "tags": [ "integration" ]
   },
   {
     "name": "Connect for Kentico",
@@ -585,9 +585,9 @@
     "author": "BizStream",
     "sourceUrl": "https://www.bizstreamtoolkit.com/extensions/connect-for-kentico",
     "version": "2.0.69",
-    "kenticoVersions": ["10.0.0", "11.0.0"],
+    "kenticoVersions": [ "10.0.0", "11.0.0" ],
     "category": "integration",
-    "tags": ["integration"]
+    "tags": [ "integration" ]
   },
   {
     "name": "Kentico Power BI reports",
@@ -596,9 +596,9 @@
     "author": "Kentico",
     "sourceUrl": "https://devnet.kentico.com/old-marketplace/integration/kentico-power-bi-reports",
     "version": "1.0.0",
-    "kenticoVersions": ["10.0.0", "11.0.0", "12.0.0"],
+    "kenticoVersions": [ "10.0.0", "11.0.0", "12.0.0" ],
     "category": "integration",
-    "tags": ["integration"]
+    "tags": [ "integration" ]
   },
   {
     "name": "Compare for Kentico",
@@ -607,9 +607,9 @@
     "author": "BizStream",
     "sourceUrl": "https://www.bizstreamtoolkit.com/products/compare",
     "version": "1.0.0",
-    "kenticoVersions": ["10.0.0"],
+    "kenticoVersions": [ "10.0.0" ],
     "category": "integration",
-    "tags": ["integration"]
+    "tags": [ "integration" ]
   },
   {
     "name": "Bootstrap 4 Layout Tool",
@@ -618,9 +618,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/BootstrapLayoutTool/blob/master/README.md",
     "version": "13.0.0",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "mvc section",
-    "tags": ["section", "bootstrap", "columns"]
+    "tags": [ "section", "bootstrap", "columns" ]
   },
   {
     "name": "Multiple Page Selector",
@@ -629,9 +629,9 @@
     "author": "IDHL",
     "sourceUrl": "https://github.com/netconstruct/kentico-xperience-13-multiple-page-selector",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "other",
-    "tags": ["form component", "page selector", "multiple"]
+    "tags": [ "form component", "page selector", "multiple" ]
   },
   {
     "name": "Tiny MCE Wysiwyg Editor",
@@ -640,9 +640,9 @@
     "author": "Troy Landers -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/TinyMCE_Wysiwyg",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["wysiwyg", "tinymce", "rich text", "editable text", "html"]
+    "tags": [ "wysiwyg", "tinymce", "rich text", "editable text", "html" ]
   },
   {
     "name": "Partial Widget Page",
@@ -651,9 +651,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/PartialWidgetPage",
     "version": "13.0.3",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "utility",
-    "tags": ["page placeholder", "page builder", "widgets"]
+    "tags": [ "page placeholder", "page builder", "widgets" ]
   },
   {
     "name": "Bing Maps MVC Widget",
@@ -662,9 +662,9 @@
     "author": "Ondrabus",
     "sourceUrl": "https://github.com/ondrabus/kentico-mvcwidget-bing-maps",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["mvc", "bing", "maps"]
+    "tags": [ "mvc", "bing", "maps" ]
   },
   {
     "name": "Page Builder Containers",
@@ -673,9 +673,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/PageBuilderContainers",
     "version": "13.0.3",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "utility",
-    "tags": ["webpart containers", "containers"]
+    "tags": [ "webpart containers", "containers" ]
   },
   {
     "name": "Color Picker",
@@ -684,9 +684,9 @@
     "author": "Joshua Hess - Heartland Business Systems",
     "sourceUrl": "https://github.com/farmergeek94/ColorPickerFormComponent",
     "version": "12.29.4",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc form component",
-    "tags": ["color", "picker", "hex"]
+    "tags": [ "color", "picker", "hex" ]
   },
   {
     "name": "Date Time Picker",
@@ -695,9 +695,9 @@
     "author": "Joshua Hess - Heartland Business Systems",
     "sourceUrl": "https://github.com/farmergeek94/DatePickerFormComponent",
     "version": "12.29.1",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc form component",
-    "tags": ["date", "picker", "datetime", "date time"]
+    "tags": [ "date", "picker", "datetime", "date time" ]
   },
   {
     "name": "Email Marketing & Surveys",
@@ -706,7 +706,7 @@
     "author": "SensorPro",
     "sourceUrl": "https://github.com/SensorPro/KenticoContacts",
     "version": "1.0.0",
-    "kenticoVersions": ["11.0.0", "11.0.49", "12.0.29", "12.0.40"],
+    "kenticoVersions": [ "11.0.0", "11.0.49", "12.0.29", "12.0.40" ],
     "category": "module",
     "tags": [
       "integration",
@@ -725,9 +725,9 @@
     "author": "Ondrabus",
     "sourceUrl": "https://github.com/ondrabus/kentico-mvcwidget-lightbox-gallery",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["mvc", "bing", "lightbox", "gallery"]
+    "tags": [ "mvc", "bing", "lightbox", "gallery" ]
   },
   {
     "name": "MVC Caching for Kentico",
@@ -736,9 +736,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/MVCCaching",
     "version": "13.0.0",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "utility",
-    "tags": ["cache", "caching"]
+    "tags": [ "cache", "caching" ]
   },
   {
     "name": "Content components",
@@ -747,9 +747,9 @@
     "author": "Chris Meagher",
     "sourceUrl": "https://github.com/CMeeg/kentico-contrib/tree/master/src/Meeg.Kentico.ContentComponents",
     "version": "0.3.0",
-    "kenticoVersions": ["12.0.39"],
+    "kenticoVersions": [ "12.0.39" ],
     "category": "module",
-    "tags": ["content", "content modelling", "page types"]
+    "tags": [ "content", "content modelling", "page types" ]
   },
   {
     "name": "Disqus Thread MVC Widget",
@@ -758,9 +758,9 @@
     "author": "Aviva Solutions",
     "sourceUrl": "https://github.com/avivasolutionsnl/kentico-mvc-widget-disqus",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.38"],
+    "kenticoVersions": [ "12.0.38" ],
     "category": "mvc widget",
-    "tags": ["mvc", "comments", "disqus"]
+    "tags": [ "mvc", "comments", "disqus" ]
   },
   {
     "name": "Kentico Kontent publishing module",
@@ -769,9 +769,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-module-kontent-publishing",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "integration",
-    "tags": ["headless", "headless_API", "API", "Kontent"]
+    "tags": [ "headless", "headless_API", "API", "Kontent" ]
   },
   {
     "name": "Automatic Generic User Roles",
@@ -780,9 +780,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/AutomaticGenericUserRoles",
     "version": "13.0.0",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "utility",
-    "tags": ["utility", "other"]
+    "tags": [ "utility", "other" ]
   },
   {
     "name": "FullCalendar MVC Widget",
@@ -791,9 +791,9 @@
     "author": "Dragoljub Ilic (EXLRT)",
     "sourceUrl": "https://github.com/drilic/kentico-mvcwidget-fullcalendar/",
     "version": "2.0.0",
-    "kenticoVersions": ["12.0.41", "13.0.97"],
+    "kenticoVersions": [ "12.0.41", "13.0.97" ],
     "category": "mvc widget",
-    "tags": ["mvc", "widget", "calendar", "fullCalendar", "events"]
+    "tags": [ "mvc", "widget", "calendar", "fullCalendar", "events" ]
   },
   {
     "name": "YouTube Video Selector",
@@ -802,9 +802,9 @@
     "author": "Matt Nield - Ridgeway",
     "sourceUrl": "https://github.com/mattnield/kentico-youtube-selector-widget",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "mvc widget",
-    "tags": ["YouTube", "mvc", "video", "inline", "video search"]
+    "tags": [ "YouTube", "mvc", "video", "inline", "video search" ]
   },
   {
     "name": "Recombee Content Recommendations",
@@ -813,7 +813,7 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-module-recombee",
     "version": "0.0.1-preview",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
     "tags": [
       "Recommendations",
@@ -831,9 +831,9 @@
     "author": "Trevor Fayas-HBS, Sean Wright-WiredViews",
     "sourceUrl": "https://github.com/KenticoDevTrev/DynamicRouting/tree/DynamicRouting-Only",
     "version": "12.29.1",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "utility",
-    "tags": ["dynamic routing", "routing", "url"]
+    "tags": [ "dynamic routing", "routing", "url" ]
   },
   {
     "name": "ImageMagick Image Optimization",
@@ -842,9 +842,9 @@
     "author": "Dmitry Bastron, Delete Ltd.",
     "sourceUrl": "https://github.com/diger74/DeleteAgency.Kentico12.ImageMagick",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "module",
-    "tags": ["ImageMagick", "Image optimization"]
+    "tags": [ "ImageMagick", "Image optimization" ]
   },
   {
     "name": "TinyPNG Image Optimization",
@@ -853,40 +853,40 @@
     "author": "Dmitry Bastron, Delete Ltd.",
     "sourceUrl": "https://github.com/diger74/DeleteAgency.Kentico12.TinyPng",
     "version": "1.1.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "module",
     "tags": [
       "TinyPNG",
       "Image optimization"
     ]
-  },	
+  },
   {
-   "name": "Carousel widget",
-   "description": "Carousel widget for Kentico MVC",
-   "thumbnailUrl": "https://raw.githubusercontent.com/Machmin/FLS.Kentico.Marketplace/master/FLS.Kentico.MvcWidget.Carousel/fls.png",
-   "author": "First line software",
-   "sourceUrl": "https://github.com/Machmin/FLS.Kentico.Marketplace/tree/master/FLS.Kentico.MvcWidget.Carousel",
-   "version": "0.0.9",
-   "kenticoVersions": [
-     "12.0.29"
-   ],
-   "category": "mvc widget",
-   "tags": [
-     "mvc",
-     "carousel",
-	 "image"
-   ]
- },
-    {
+    "name": "Carousel widget",
+    "description": "Carousel widget for Kentico MVC",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Machmin/FLS.Kentico.Marketplace/master/FLS.Kentico.MvcWidget.Carousel/fls.png",
+    "author": "First line software",
+    "sourceUrl": "https://github.com/Machmin/FLS.Kentico.Marketplace/tree/master/FLS.Kentico.MvcWidget.Carousel",
+    "version": "0.0.9",
+    "kenticoVersions": [
+      "12.0.29"
+    ],
+    "category": "mvc widget",
+    "tags": [
+      "mvc",
+      "carousel",
+      "image"
+    ]
+  },
+  {
     "name": "CKEditor4 Wysiwyg Editor",
     "description": "Adds CKEditor4 Wysiwyg editor capabilities for MVC. Includes CKEditor4 Widget and Inline Editor.",
     "thumbnailUrl": "https://raw.githubusercontent.com/TimLemke/CKEditor4_Wysiwyg/master/SeventyeightDigitalLogo.jpg",
     "author": "Tim Lemke - Seventyeight Digital Inc.",
     "sourceUrl": "https://github.com/TimLemke/CKEditor4_Wysiwyg",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["wysiwyg", "ckeditor4", "editable text", "html"]
+    "tags": [ "wysiwyg", "ckeditor4", "editable text", "html" ]
   },
   {
     "name": "Placeholder Image Widget",
@@ -895,9 +895,9 @@
     "author": "Tim Lemke - Seventyeight Digital Inc.",
     "sourceUrl": "https://github.com/TimLemke/PlaceholderImageWidget",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["Placeholder", "Images", "Widget"]
+    "tags": [ "Placeholder", "Images", "Widget" ]
   },
   {
     "name": "Masonry Image Gallery Widget",
@@ -906,9 +906,9 @@
     "author": "Tim Lemke - Seventyeight Digital Inc.",
     "sourceUrl": "https://github.com/TimLemke/MasonryImageGalleryWidget",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["Masonry", "Image", "Gallery"]
+    "tags": [ "Masonry", "Image", "Gallery" ]
   },
   {
     "name": "Plyr Media Player Widget",
@@ -917,42 +917,42 @@
     "author": "Tim Lemke - Seventyeight Digital Inc.",
     "sourceUrl": "https://github.com/TimLemke/PlyrMediaPlayerWidget",
     "version": "12.29.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc widget",
-    "tags": ["Media", "Player", "HTML5", "Audio", "Video", "Youtube", "Vimeo"]
+    "tags": [ "Media", "Player", "HTML5", "Audio", "Video", "Youtube", "Vimeo" ]
   },
   {
-	"name": "URL Redirection Module",
-	"description": "A module that adds support for adding and managing URL redirects through the Kentico CMS interface.",
-	"thumbnailUrl": "https://github.com/silvertech/KenticoURLRedirectionModule/blob/master/silvertech-logo.png?raw=true",
-	"author": "SilverTech, Inc.",
-	"sourceUrl": "https://github.com/silvertech/KenticoURLRedirectionModule",
-	"version": "12.0.4",
-	"kenticoVersions": ["12.0.52"],
-	"category": "module",
-	"tags": ["url", "redirection", "module"]
+    "name": "URL Redirection Module",
+    "description": "A module that adds support for adding and managing URL redirects through the Kentico CMS interface.",
+    "thumbnailUrl": "https://github.com/silvertech/KenticoURLRedirectionModule/blob/master/silvertech-logo.png?raw=true",
+    "author": "SilverTech, Inc.",
+    "sourceUrl": "https://github.com/silvertech/KenticoURLRedirectionModule",
+    "version": "12.0.4",
+    "kenticoVersions": [ "12.0.52" ],
+    "category": "module",
+    "tags": [ "url", "redirection", "module" ]
   },
   {
-	"name": "Automated Image Compressor",
-	"description": "A utility to automatically compress images uploaded into a kentico media library.",
-	"thumbnailUrl": "https://raw.githubusercontent.com/QubaDigitalUK/KenticoCMS.Compressor/master/quba.jpg",
-	"author": "Quba",
-	"sourceUrl": "https://github.com/QubaDigitalUK/KenticoCMS.Compressor",
-	"version": "1.0.0",
-	"kenticoVersions": ["12.0.52"],
-	"category": "utility",
-	"tags": ["image", "compression", "performance", "utility"]
+    "name": "Automated Image Compressor",
+    "description": "A utility to automatically compress images uploaded into a kentico media library.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/QubaDigitalUK/KenticoCMS.Compressor/master/quba.jpg",
+    "author": "Quba",
+    "sourceUrl": "https://github.com/QubaDigitalUK/KenticoCMS.Compressor",
+    "version": "1.0.0",
+    "kenticoVersions": [ "12.0.52" ],
+    "category": "utility",
+    "tags": [ "image", "compression", "performance", "utility" ]
   },
   {
-	"name": "Slack Integration",
-	"description": "A quick and easy way to setup automatic slack messaging for Kentico",
-	"thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/Orange_Wakefly_Logo.png",
-	"author": "Wakefly Inc.",
-	"sourceUrl": "https://bitbucket.org/wakeflyinc/wakefly-slack-integration-marketplace-plugin/src/master/",
-	"version": "1.0.0",
-	"kenticoVersions": ["12.0.29"],
-	"category": "utility",
-	"tags": ["Slack", "messaging", "workflow", "utility"]
+    "name": "Slack Integration",
+    "description": "A quick and easy way to setup automatic slack messaging for Kentico",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/Orange_Wakefly_Logo.png",
+    "author": "Wakefly Inc.",
+    "sourceUrl": "https://bitbucket.org/wakeflyinc/wakefly-slack-integration-marketplace-plugin/src/master/",
+    "version": "1.0.0",
+    "kenticoVersions": [ "12.0.29" ],
+    "category": "utility",
+    "tags": [ "Slack", "messaging", "workflow", "utility" ]
   },
   {
     "name": "CMS Settings Config Builder",
@@ -961,21 +961,21 @@
     "author": "Chris Meagher",
     "sourceUrl": "https://github.com/CMeeg/kentico-contrib/tree/master/src/Meeg.Kentico.Configuration",
     "version": "0.1.0",
-    "kenticoVersions": ["12.0.39"],
+    "kenticoVersions": [ "12.0.39" ],
     "category": "module",
-    "tags": ["configuration", "configuration builder", "settings"]
+    "tags": [ "configuration", "configuration builder", "settings" ]
   },
-	{
-        "name": "GatherContent Integration",
-        "description": "GatherContent’s Kentico integration allows content editors to import and update content from GatherContent to Kentico.",
-        "thumbnailUrl": "https://raw.githubusercontent.com/gathercontent/kentico-plugin/release/v12/marketplace/assets/kentico-icon.png",
-        "author": "Brimit",
-        "sourceUrl": "https://github.com/gathercontent/kentico-plugin/tree/release/v12",
-        "version": "12.0.1",
-        "kenticoVersions": ["12.0.29"],
-        "category": "module",
-        "tags": ["GatherContent", "integration", "module"]
-    },
+  {
+    "name": "GatherContent Integration",
+    "description": "GatherContent’s Kentico integration allows content editors to import and update content from GatherContent to Kentico.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/gathercontent/kentico-plugin/release/v12/marketplace/assets/kentico-icon.png",
+    "author": "Brimit",
+    "sourceUrl": "https://github.com/gathercontent/kentico-plugin/tree/release/v12",
+    "version": "12.0.1",
+    "kenticoVersions": [ "12.0.29" ],
+    "category": "module",
+    "tags": [ "GatherContent", "integration", "module" ]
+  },
   {
     "name": "Email Marketing Widgets and Templates",
     "description": "A collection of responsive email marketing widgets and templates for Kentico EMS.",
@@ -983,9 +983,9 @@
     "author": "3 Degrees North",
     "sourceUrl": "https://github.com/3dn-services/kentico-email-widgets",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.0"],
+    "kenticoVersions": [ "12.0.0" ],
     "category": "other",
-    "tags": ["email", "template", "widget", "ems", "marketing"]
+    "tags": [ "email", "template", "widget", "ems", "marketing" ]
   },
   {
     "name": "Email Widgets",
@@ -994,9 +994,9 @@
     "author": "Lukas Bajer",
     "sourceUrl": "https://github.com/lukas-xb/kentico-email-builder-components",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.45"],
+    "kenticoVersions": [ "12.0.45" ],
     "category": "other",
-    "tags": ["email", "widget","ems"]
+    "tags": [ "email", "widget", "ems" ]
   },
   {
     "name": "Invisible ReCaptcha",
@@ -1005,64 +1005,64 @@
     "author": "Josh Kerbaugh - Citro Digital",
     "sourceUrl": "https://github.com/CitroDigital/InvisibleRecpatcha",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.43"],
+    "kenticoVersions": [ "12.0.43" ],
     "category": "mvc form component",
-    "tags": ["recaptcha"]
+    "tags": [ "recaptcha" ]
   },
   {
-   "name":"Custom Table Macro",
-   "description": "Macro allows to render Custom table field value in transformation",
-   "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/CustomTableMacro/master/SIPL.png",
-   "author": "Systematix Infotech Pvt. Ltd.",
-   "sourceUrl": "https://github.com/dilip-sipl/CustomTableMacro",
-   "version": "1.0.0",
-   "kenticoVersions": ["11.0.0"],
-   "category": "other",
-   "tags": ["macro","custom-table","transformation","Text/XML","ASCX"]
- },
- {
+    "name": "Custom Table Macro",
+    "description": "Macro allows to render Custom table field value in transformation",
+    "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/CustomTableMacro/master/SIPL.png",
+    "author": "Systematix Infotech Pvt. Ltd.",
+    "sourceUrl": "https://github.com/dilip-sipl/CustomTableMacro",
+    "version": "1.0.0",
+    "kenticoVersions": [ "11.0.0" ],
+    "category": "other",
+    "tags": [ "macro", "custom-table", "transformation", "Text/XML", "ASCX" ]
+  },
+  {
     "name": "Image Focuspoint",
     "description": "Image focuspoint provides helper tool for Kentico CMS to ensure that the spare parts of your image (negative space) are cropped out before the important parts.",
     "thumbnailUrl": "https://raw.githubusercontent.com/drilic/kentico-mvcformcontrol-focuspoint/master/exlrt-logo-clear.png",
     "author": "Dragoljub Ilic (EXLRT)",
     "sourceUrl": "https://github.com/drilic/kentico-mvcformcontrol-focuspoint",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.77"],
+    "kenticoVersions": [ "12.0.77" ],
     "category": "mvc form component",
-    "tags": ["focuspoint", "focus", "image", "form control"]
+    "tags": [ "focuspoint", "focus", "image", "form control" ]
   },
-{
-   "name": "Document Category Widget",
-   "description": "Document categories allows you to see the categories assigned to the current page",
-   "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/Document-categories-widget/master/SIPL.png",
-   "author": "Systematix Infotech Pvt. Ltd.",
-   "sourceUrl": "https://github.com/dilip-sipl/Document-categories-widget",
-   "version": "1.0.0",
-   "kenticoVersions": ["12.0.52"],
-   "category": "mvc widget",
-   "tags": ["kentico 12 mvc","mvc widget","categories","current document","separators"]
- },
-{
-   "name": "Current Page Categories Widget",
-   "description": "Page categories widget can be added as an inline widget in editable region or in widget zone, and will display categories of current page.",
-   "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/Current-page-categories/master/SIPL.png",
-   "author": "Systematix Infotech Pvt. Ltd.",
-   "sourceUrl": "https://github.com/dilip-sipl/Current-page-categories",
-   "version": "1.0.0",
-   "kenticoVersions": ["11.0.27"],
-   "category": "other",
-   "tags": ["categories","current page","separators","portal","widget"]
- },
- {
-  "name": "Cookieless Form Handler Module",
-  "description": "Enables using online forms and marketing automation without cookie consent.  Allows responding to forms with marketing automation and marketing emails.",
-  "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/bluemodus-icon.png",
-  "author": "Mike Wills, BlueModus",
-  "sourceUrl": "https://github.com/heywills/CookielessFormHandler",
-  "version": "1.0.0",
-  "kenticoVersions": ["12.0.39"],
-  "category": "module",
-  "tags": ["forms", "online forms", "marketing automation", "email marketing", "cookie consent", "gdpr", "ccpa"]
+  {
+    "name": "Document Category Widget",
+    "description": "Document categories allows you to see the categories assigned to the current page",
+    "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/Document-categories-widget/master/SIPL.png",
+    "author": "Systematix Infotech Pvt. Ltd.",
+    "sourceUrl": "https://github.com/dilip-sipl/Document-categories-widget",
+    "version": "1.0.0",
+    "kenticoVersions": [ "12.0.52" ],
+    "category": "mvc widget",
+    "tags": [ "kentico 12 mvc", "mvc widget", "categories", "current document", "separators" ]
+  },
+  {
+    "name": "Current Page Categories Widget",
+    "description": "Page categories widget can be added as an inline widget in editable region or in widget zone, and will display categories of current page.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/Current-page-categories/master/SIPL.png",
+    "author": "Systematix Infotech Pvt. Ltd.",
+    "sourceUrl": "https://github.com/dilip-sipl/Current-page-categories",
+    "version": "1.0.0",
+    "kenticoVersions": [ "11.0.27" ],
+    "category": "other",
+    "tags": [ "categories", "current page", "separators", "portal", "widget" ]
+  },
+  {
+    "name": "Cookieless Form Handler Module",
+    "description": "Enables using online forms and marketing automation without cookie consent.  Allows responding to forms with marketing automation and marketing emails.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/bluemodus-icon.png",
+    "author": "Mike Wills, BlueModus",
+    "sourceUrl": "https://github.com/heywills/CookielessFormHandler",
+    "version": "1.0.0",
+    "kenticoVersions": [ "12.0.39" ],
+    "category": "module",
+    "tags": [ "forms", "online forms", "marketing automation", "email marketing", "cookie consent", "gdpr", "ccpa" ]
   },
   {
     "name": "Staging Configuration Module",
@@ -1071,9 +1071,9 @@
     "author": "Mike Wills, BlueModus",
     "sourceUrl": "https://github.com/heywills/StagingConfigurationModule",
     "version": "13.0.5",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "module",
-    "tags": ["staging", "deployment", "synchronization"]
+    "tags": [ "staging", "deployment", "synchronization" ]
   },
   {
     "name": "Category Selector Form Component",
@@ -1082,20 +1082,20 @@
     "author": "Visual Antidote",
     "sourceUrl": "https://github.com/visual-antidote/Kentico.MVC.FormComponent.CategorySelector",
     "version": "1.0.1",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "mvc form component",
-    "tags": ["kentico","mvc","form","component","category","categories","VisualAntidote"]
+    "tags": [ "kentico", "mvc", "form", "component", "category", "categories", "VisualAntidote" ]
   },
-{
-   "name": "Current user display Widget",
-   "description": "Widget will display the property value of logged in user based on selected property name in widget configuration",
-   "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/Current-user-display/master/SIPL.png",
-   "author": "Systematix Infotech Pvt. Ltd.",
-   "sourceUrl": "https://github.com/dilip-sipl/Current-user-display",
-   "version": "1.0.0",
-   "kenticoVersions": ["12.0.83"],
-   "category": "mvc widget",
-   "tags": ["current user","user details", "logged in user","mvc", "widget"]
+  {
+    "name": "Current user display Widget",
+    "description": "Widget will display the property value of logged in user based on selected property name in widget configuration",
+    "thumbnailUrl": "https://raw.githubusercontent.com/dilip-sipl/Current-user-display/master/SIPL.png",
+    "author": "Systematix Infotech Pvt. Ltd.",
+    "sourceUrl": "https://github.com/dilip-sipl/Current-user-display",
+    "version": "1.0.0",
+    "kenticoVersions": [ "12.0.83" ],
+    "category": "mvc widget",
+    "tags": [ "current user", "user details", "logged in user", "mvc", "widget" ]
   },
   {
     "name": "Upsert Alternative Forms Provider",
@@ -1104,9 +1104,9 @@
     "author": "Mike Wills, BlueModus",
     "sourceUrl": "https://github.com/heywills/upsert-alternative-forms",
     "version": "13.0.0",
-    "kenticoVersions": ["11.0.0", "12.0.0", "13.0.0"],
+    "kenticoVersions": [ "11.0.0", "12.0.0", "13.0.0" ],
     "category": "other",
-    "tags": ["page type", "alternative form", "user experience"]
+    "tags": [ "page type", "alternative form", "user experience" ]
   },
   {
     "name": "CTA Button",
@@ -1115,9 +1115,9 @@
     "author": "Sam Collins - Integranet Digital",
     "sourceUrl": "https://github.com/IntegranetSam/K12_Integranet_WebPart_CTAButton",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.29"],
+    "kenticoVersions": [ "12.0.29" ],
     "category": "webpart",
-    "tags": ["cta", "button", "widget", "web part"]
+    "tags": [ "cta", "button", "widget", "web part" ]
   },
   {
     "name": "Kentico 13 Core Baseline",
@@ -1126,9 +1126,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/HBSTech/Kentico13CoreBaseline",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.5"],
+    "kenticoVersions": [ "13.0.5" ],
     "category": "website template",
-    "tags": ["baseline", "mvc", "core", "site"]
+    "tags": [ "baseline", "mvc", "core", "site" ]
   },
   {
     "name": "Kentico 12 Baseline",
@@ -1137,9 +1137,9 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/HBSTech/Kentico12Baseline",
     "version": "1.0.0",
-    "kenticoVersions": ["12.0.79"],
+    "kenticoVersions": [ "12.0.79" ],
     "category": "website template",
-    "tags": ["baseline", "mvc", "core", "site"]
+    "tags": [ "baseline", "mvc", "core", "site" ]
   },
   {
     "name": "Page Asset Folder Module",
@@ -1148,9 +1148,9 @@
     "author": "Mike Wills, BlueModus",
     "sourceUrl": "https://github.com/heywills/page-asset-folder-module",
     "version": "13.0.0",
-    "kenticoVersions": ["12.0.0", "13.0.0"],
+    "kenticoVersions": [ "12.0.0", "13.0.0" ],
     "category": "module",
-    "tags": ["page type", "allowed types", "user experience", "asset folders"]
+    "tags": [ "page type", "allowed types", "user experience", "asset folders" ]
   },
   {
     "name": "URL Redirection Module",
@@ -1159,29 +1159,29 @@
     "author": "Trevor Fayas -Heartland Business Systems",
     "sourceUrl": "https://github.com/KenticoDevTrev/KenticoURLRedirectionModule",
     "version": "13.0.2",
-    "kenticoVersions": ["12.0.29", "13.0.0"],
+    "kenticoVersions": [ "12.0.29", "13.0.0" ],
     "category": "module",
-    "tags": ["url", "redirection", "module"]
+    "tags": [ "url", "redirection", "module" ]
   },
   {
-   "name": "Filter Cards List By Categories Widget",
-   "description": "Widget displays page types list and categories filter that allowing pages to be filtered by categories",
-   "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/generic-integration.png",
-   "author": "BitsOrchestra",
-   "sourceUrl": "https://github.com/mzhokh/FilterByCategoryWidget/tree/main/FilterByCategoryWidget",
-   "version": "1.0.0",
-   "kenticoVersions": ["12.0.67"],
-   "category": "mvc widget",
-   "tags": ["mvc", "categories", "images", "cards", "filter", "page types" ]
- },
- {
+    "name": "Filter Cards List By Categories Widget",
+    "description": "Widget displays page types list and categories filter that allowing pages to be filtered by categories",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/generic-integration.png",
+    "author": "BitsOrchestra",
+    "sourceUrl": "https://github.com/mzhokh/FilterByCategoryWidget/tree/main/FilterByCategoryWidget",
+    "version": "1.0.0",
+    "kenticoVersions": [ "12.0.67" ],
+    "category": "mvc widget",
+    "tags": [ "mvc", "categories", "images", "cards", "filter", "page types" ]
+  },
+  {
     "name": "Intercom Integration",
     "description": "Provides contact data synchronization, allows activity logging in Xperience based on the Intercom chat, and simplifies adding of the Intercom scripts on pages.",
     "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/intercom-logo.png",
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-module-intercom",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
     "tags": [ "module", "intergration", "Intercom", "chat", "chatbot" ]
   },
@@ -1192,7 +1192,7 @@
     "author": "Ben Murphy",
     "sourceUrl": "https://github.com/BenMurphyUK/BM.GeneralLinksComponent",
     "version": "13.0.52",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "mvc form component",
     "tags": [ "mvc", "component", "link", "widget", "property", "page builder" ]
   },
@@ -1203,9 +1203,9 @@
     "author": "Andrew Coats, BlueModus",
     "sourceUrl": "https://github.com/bluemodus/KenticoCommunity.ContinuousIntegration",
     "version": "13.0.5",
-    "kenticoVersions": ["0.0.1"],
+    "kenticoVersions": [ "0.0.1" ],
     "category": "module",
-    "tags": ["azure", "deployment", "security"]
+    "tags": [ "azure", "deployment", "security" ]
   },
   {
     "name": "Page listing widget",
@@ -1214,9 +1214,9 @@
     "author": "Kentico",
     "sourceUrl": "https://github.com/Kentico/xperience-listing-widget",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.52"],
+    "kenticoVersions": [ "13.0.52" ],
     "category": "mvc widget",
-    "tags": ["core", "component", "widget", "listing"]
+    "tags": [ "core", "component", "widget", "listing" ]
   },
   {
     "name": "XTM Connect for Kentico Xperience",
@@ -1225,53 +1225,53 @@
     "author": "XTM International",
     "sourceUrl": "https://github.com/xtm-connect/XTM-Connect-for-Kentico-Xperience",
     "version": "3.1.1",
-    "kenticoVersions": ["13.0.0"],
+    "kenticoVersions": [ "13.0.0" ],
     "category": "integration",
-    "tags": ["XTM", "translation", "integration", "XTM.Cloud"]
+    "tags": [ "XTM", "translation", "integration", "XTM.Cloud" ]
   },
-  { 
+  {
     "name": "YouTube Video widget",
     "description": "Widget Enables to insert the video from specified YouTube URL location.",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/RBT-Xperience-Core-Components-YouTube-Video",
     "version": "1.0.2",
-    "kenticoVersions": ["13.0.73"],
+    "kenticoVersions": [ "13.0.73" ],
     "category": "mvc widget",
-    "tags": ["core", "youtube", "youtue video", "Video","Kentico 13","Xperience 13"]
-	},
-	  { 
+    "tags": [ "core", "youtube", "youtue video", "Video", "Kentico 13", "Xperience 13" ]
+  },
+  {
     "name": "Google Map widget",
     "description": "It displays map obtained from the Google maps service using Latitude,Longitude and Google API Key.",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/RBT-Xperience-Core-Components-Google-Map",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.73"],
+    "kenticoVersions": [ "13.0.73" ],
     "category": "mvc widget",
-    "tags": ["core", "google", "google map", "map","Kentico 13","Xperience 13"]
-	},
-	  { 
+    "tags": [ "core", "google", "google map", "map", "Kentico 13", "Xperience 13" ]
+  },
+  {
     "name": "Editable Image widget",
     "description": "It will render the image which can be seleted from media library and allows editors to add class, alt text, dimensions and redirection link to image.",
     "thumbnailUrl": "https://raw.githubusercontent.com/vasu-rbt/devnet.kentico.com/master/marketplace/assets/raybiztech-logo.png",
     "author": "Ray Business Technologies Pvt Ltd.",
     "sourceUrl": "https://github.com/vasu-rbt/rbt-xperience-core-components-editable-image",
     "version": "1.0.0",
-    "kenticoVersions": ["13.0.73"],
+    "kenticoVersions": [ "13.0.73" ],
     "category": "mvc widget",
-    "tags": ["core", "Editable", "Editable image", "image","Kentico 13","Xperience 13"]
-	},
+    "tags": [ "core", "Editable", "Editable image", "image", "Kentico 13", "Xperience 13" ]
+  },
   {
-   "name": "TreeNode Selector Form Control",
-   "description": "This Kentico Xperience form control provides a tree-based selector, with configurable page type and path filters.",
-   "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/bluemodus-icon.png",
-   "author": "Mike Wills, BlueModus",
-   "sourceUrl": "https://github.com/heywills/xperience-treenode-selector-form-control",
-   "version": "1.0.2",
-   "kenticoVersions": ["13.0.0"],
-   "category": "other",
-   "tags": ["form control", "content", "web forms", "page types", "selector"]
+    "name": "TreeNode Selector Form Control",
+    "description": "This Kentico Xperience form control provides a tree-based selector, with configurable page type and path filters.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/bluemodus-icon.png",
+    "author": "Mike Wills, BlueModus",
+    "sourceUrl": "https://github.com/heywills/xperience-treenode-selector-form-control",
+    "version": "1.0.2",
+    "kenticoVersions": [ "13.0.0" ],
+    "category": "other",
+    "tags": [ "form control", "content", "web forms", "page types", "selector" ]
   },
   {
     "name": "MultiSelect Dropdown Form Control",
@@ -1294,5 +1294,16 @@
     "kenticoVersions": [ "13.0.104" ],
     "category": "other",
     "tags": [ "core", "form control", "Kentico 13", "Xperience 13" ]
+  },
+  {
+    "name": "Xperience By Kentico Video Widget",
+    "description": "The Video Widget for Xperience by Kentico allows you to seamlessly embed Vimeo and YouTube videos into your website.",
+    "thumbnailUrl": "https://raw.githubusercontent.com/Kentico/devnet.kentico.com/master/marketplace/assets/dotstark-icon.png",
+    "author": "Manthan Jangid, DotStark Technologies",
+    "sourceUrl": "https://github.com/DotStarkTechnologies/XBK-Video-Widget",
+    "version": "1.0.0",
+    "kenticoVersions": [ "29.4.0" ],
+    "category": "integration",
+    "tags": [ "core", "xperience by kentico", "video", "widget" ]
   }
 ]


### PR DESCRIPTION
Implemented Video widget for Xperience By Kentico

The **Video Widget** for Xperience by Kentico allows you to seamlessly embed Vimeo and YouTube videos into your website. The widget provides options for video source selection, whether via URL or embed code, and allows customization through CSS classes.

### Widget Properties

The widget provides several configurable properties:

- **Visible**: Determines if the video is visible on the live site.
- **Source**: Specifies the source type for the video, allowing selection between an embed code or a video URL.
- **Video Url**: The URL of the video, which can be from YouTube or Vimeo. This property is only visible when the `Source` property is set to "videoUrl".
- **Embed Code**: The embed code for the video, which can be used to directly embed the video into the page. This property is only visible when the `Source` property is set to "embedCode".
- **Css classes**: Custom CSS classes to apply to the video's containing DIV.